### PR TITLE
make GetPasswd take a terminal file descriptor

### DIFF
--- a/bsd.go
+++ b/bsd.go
@@ -8,7 +8,7 @@ package gopass
 #include <stdio.h>
 
 int getch(int termDescriptor) {
-        int ch;
+        char ch;
         struct termios t_old, t_new;
 
         tcgetattr(termDescriptor, &t_old);
@@ -16,10 +16,15 @@ int getch(int termDescriptor) {
         t_new.c_lflag &= ~(ICANON | ECHO);
         tcsetattr(termDescriptor, TCSANOW, &t_new);
 
-        ch = getchar();
+        ssize_t size = read(termDescriptor, &ch, sizeof(ch));
 
         tcsetattr(termDescriptor, TCSANOW, &t_old);
-        return ch;
+
+        if (size == 0) {
+            return -1;
+        } else {
+            return ch;
+        }
 }
 */
 import "C"

--- a/bsd.go
+++ b/bsd.go
@@ -7,23 +7,23 @@ package gopass
 #include <unistd.h>
 #include <stdio.h>
 
-int getch() {
+int getch(int termDescriptor) {
         int ch;
         struct termios t_old, t_new;
 
-        tcgetattr(STDIN_FILENO, &t_old);
+        tcgetattr(termDescriptor, &t_old);
         t_new = t_old;
         t_new.c_lflag &= ~(ICANON | ECHO);
-        tcsetattr(STDIN_FILENO, TCSANOW, &t_new);
+        tcsetattr(termDescriptor, TCSANOW, &t_new);
 
         ch = getchar();
 
-        tcsetattr(STDIN_FILENO, TCSANOW, &t_old);
+        tcsetattr(termDescriptor, TCSANOW, &t_old);
         return ch;
 }
 */
 import "C"
 
-func getch() byte {
-	return byte(C.getch())
+func getch(termDescriptor int) byte {
+	return byte(C.getch(C.int(termDescriptor)))
 }

--- a/nix.go
+++ b/nix.go
@@ -8,15 +8,15 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-func getch() byte {
-	if oldState, err := terminal.MakeRaw(0); err != nil {
+func getch(termDescriptor int) byte {
+	if oldState, err := terminal.MakeRaw(termDescriptor); err != nil {
 		panic(err)
 	} else {
-		defer terminal.Restore(0, oldState)
+		defer terminal.Restore(termDescriptor, oldState)
 	}
 
 	var buf [1]byte
-	if n, err := syscall.Read(0, buf[:]); n == 0 || err != nil {
+	if n, err := syscall.Read(termDescriptor, buf[:]); n == 0 || err != nil {
 		panic(err)
 	}
 	return buf[0]

--- a/pass.go
+++ b/pass.go
@@ -10,7 +10,7 @@ var ErrInterrupted = errors.New("Interrupted")
 // getPasswd returns the input read from terminal.
 // If masked is true, typing will be matched by asterisks on the screen.
 // Otherwise, typing will echo nothing.
-func getPasswd(masked bool) ([]byte, error) {
+func getPasswd(termDescriptor int, masked bool) ([]byte, error) {
 	var pass, bs, mask []byte
 	if masked {
 		bs = []byte("\b \b")
@@ -19,7 +19,7 @@ func getPasswd(masked bool) ([]byte, error) {
 
 	var err error
 	for {
-		if v := getch(); v == 127 || v == 8 {
+		if v := getch(termDescriptor); v == 127 || v == 8 {
 			if l := len(pass); l > 0 {
 				pass = pass[:l-1]
 				os.Stdout.Write(bs)
@@ -43,12 +43,12 @@ func getPasswd(masked bool) ([]byte, error) {
 
 // GetPasswd returns the password read from the terminal without echoing input.
 // The returned byte array does not include end-of-line characters.
-func GetPasswd() ([]byte, error) {
-	return getPasswd(false)
+func GetPasswd(termDescriptor int) ([]byte, error) {
+	return getPasswd(termDescriptor, false)
 }
 
 // GetPasswdMasked returns the password read from the terminal, echoing asterisks.
 // The returned byte array does not include end-of-line characters.
-func GetPasswdMasked() ([]byte, error) {
-	return getPasswd(true)
+func GetPasswdMasked(termDescriptor int) ([]byte, error) {
+	return getPasswd(termDescriptor, true)
 }


### PR DESCRIPTION
There are times when we need user input from the terminal, even though
our stdin is piped from something else. (For example, reading an
encrypted file over stdin, and asking the user for the password.) Make
GetPasswd\* take an explicit file descriptor for the terminal, so that
the caller has the option of using /dev/tty.
